### PR TITLE
Remove useless desktop entries

### DIFF
--- a/mkosi.conf.d/gnome.conf
+++ b/mkosi.conf.d/gnome.conf
@@ -29,3 +29,12 @@ Packages=
         rygel
         tecla
         xdg-desktop-portal-gnome
+
+RemoveFiles=
+        /usr/share/applications/avahi-discover.desktop
+        /usr/share/applications/bssh.desktop
+        /usr/share/applications/bvnc.desktop
+        /usr/share/applications/stoken-gui.desktop
+        /usr/share/applications/stoken-gui-small.desktop
+        /usr/share/applications/qv4l2.desktop
+        /usr/share/applications/qvidcap.desktop


### PR DESCRIPTION
Remove these files to clean up the desktop:
```
/usr/share/applications/avahi-discover.desktop
/usr/share/applications/bssh.desktop
/usr/share/applications/bvnc.desktop
/usr/share/applications/stoken-gui.desktop
/usr/share/applications/stoken-gui-small.desktop
/usr/share/applications/qv4l2.desktop
/usr/share/applications/qvidcap.desktop
 ```