### PR TITLE
feat: Add ootb swap setup

### DIFF
--- a/mkosi.conf.d/base.conf
+++ b/mkosi.conf.d/base.conf
@@ -46,4 +46,5 @@ Packages=
         vulkan-intel
         wl-clipboard
         xfsprogs
+        zram-generator
         7zip

--- a/mkosi.extra/usr/lib/systemd/zram-generator.conf
+++ b/mkosi.extra/usr/lib/systemd/zram-generator.conf
@@ -1,0 +1,3 @@
+[zram0]
+zram-size = min(ram / 2, 16384)
+compression-algorithm = zstd


### PR DESCRIPTION
Add zram-generator with a basic default config, it can be overwritten by the user at /etc/systemd/zram-generator.conf