### PR TITLE
(draft) Toggleable OpenTabletDriver rules

### DIFF
--- a/mkosi.conf.d/build.conf
+++ b/mkosi.conf.d/build.conf
@@ -4,3 +4,4 @@ Distribution=arch
 [Content]
 Packages=
         crane
+        jq

--- a/mkosi.postinst.chroot
+++ b/mkosi.postinst.chroot
@@ -50,4 +50,5 @@ EOF
 
 # Remove packages that are only used for building
 pacman -Rs --noconfirm \
-    crane
+    crane \
+    jq

--- a/mkosi.prepare.d/otb-rules.chroot
+++ b/mkosi.prepare.d/otb-rules.chroot
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ouex pipefail
+
+cd /tmp
+otb_tag=$(curl -s "https://api.github.com/repos/OpenTabletDriver/OpenTabletDriver/releases/latest" | jq -r '.tag_name')
+git clone https://github.com/opentabletdriver/opentabletdriver --branch ${otb_tag} && cd opentabletdriver
+
+otb_install_dir=/usr/lib/opentabletdriver-config
+install -Dm0644 <(./generate-rules.sh) ${otb_install_dir}/udev/rules.d/70-opentabletdriver.rules
+install -Dm0644 eng/bash/Generic/usr/lib/modprobe.d/99-opentabletdriver.conf -t ${otb_install_dir}/modprobe.d
+install -Dm0644 eng/bash/Generic/usr/lib/modules-load.d/opentabletdriver.conf -t ${otb_install_dir}/modules-load.d


### PR DESCRIPTION
# New PR is uploaded at #40, please look there instead.

This is a draft PR that will add in a toggleable set of rules for [OpenTabletDriver](https://opentabletdriver.net).

- [x] Automatically updated dormant rules in `/usr/lib/opentabletdriver-config`
- [ ] `ajust` script to toggle these rules on/off with a symlink (also should install/uninstall the flatpak)
