### PR TITLE
chore(ci): replace cleanup action

### DIFF
--- a/.github/workflows/build-bootc-image.yaml
+++ b/.github/workflows/build-bootc-image.yaml
@@ -26,11 +26,6 @@ on:
         required: false
         type: boolean
         default: ${{  github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
-      cleanup_action:
-        description: "Use cleanup action from ublue to get more storage on CI"
-        required: false
-        type: boolean
-        default: false
       profiles:
         description: "Extra mkosi profiles to use"
         required: false
@@ -66,13 +61,13 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-24.04
     steps:
-      - name: Mount BTRFS for podman storage
-        if: matrix.platform != 'arm64' && inputs.cleanup_action
-        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6
-        continue-on-error: true
+      - name: Free disk space
+        if: matrix.platform != 'arm64'
+        uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
         with:
-          target-dir: /var/lib/containers
-          mount-opts: compress-force=zstd:2
+          exclude: |
+            /opt/hostedtoolcache/Python
+          skip-if-available: "64G"
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
Doing the same for Zirc: https://github.com/zirconium-dev/zirconium/pull/274. Adjust the size if needed, though 64G should be enough