### PR TITLE
Toggleable OpenTabletDriver rules

### DIFF
--- a/mkosi.conf.d/build.conf
+++ b/mkosi.conf.d/build.conf
@@ -4,3 +4,4 @@ Distribution=arch
 [Content]
 Packages=
         crane
+        jq

--- a/mkosi.extra/usr/share/apollo/justfile
+++ b/mkosi.extra/usr/share/apollo/justfile
@@ -21,7 +21,7 @@ toggle-automatic-updates:
         systemctl disable --now uupd.timer
     fi
 
-# Toggles OpenTabletDriver (disables built-in kernel tablet drivers)
+# Toggles OpenTabletDriver configs (You will only be able to configure your art tablet in OpenTabletDriver, not in your desktop's settings)
 toggle-opentabletdriver:
     #!/bin/bash
     if stat /etc/.otb-toggled &>/dev/null; then
@@ -31,6 +31,12 @@ toggle-opentabletdriver:
         sudo rm /etc/.otb-toggled
         echo "Disabled OpenTabletDriver."
     else
+        if ! flatpak info net.opentabletdriver.OpenTabletDriver &>/dev/null; then
+            if gum confirm "Would you like to install OpenTabletDriver from Flathub?" ; then
+                flatpak install net.opentabletdriver.OpenTabletDriver
+            fi
+        fi
+
         sudo ln -s /usr/lib/opentabletdriver-config/udev/rules.d/70-opentabletdriver.rules /etc/udev/rules.d/70-opentabletdriver.rules
         sudo ln -s /usr/lib/opentabletdriver-config/modprobe.d/99-opentabletdriver.conf /etc/modprobe.d/99-opentabletdriver.conf
         sudo ln -s /usr/lib/opentabletdriver-config/modules-load.d/opentabletdriver.conf /etc/modules-load.d/opentabletdriver.conf

--- a/mkosi.extra/usr/share/apollo/justfile
+++ b/mkosi.extra/usr/share/apollo/justfile
@@ -31,15 +31,21 @@ toggle-opentabletdriver:
         sudo rm /etc/.otb-toggled
         echo "Disabled OpenTabletDriver."
     else
+        set -euo pipefail
+
         if ! flatpak info net.opentabletdriver.OpenTabletDriver &>/dev/null; then
             if gum confirm "Would you like to install OpenTabletDriver from Flathub?" ; then
                 flatpak install net.opentabletdriver.OpenTabletDriver
             fi
         fi
 
-        sudo ln -s /usr/lib/opentabletdriver-config/udev/rules.d/70-opentabletdriver.rules /etc/udev/rules.d/70-opentabletdriver.rules
-        sudo ln -s /usr/lib/opentabletdriver-config/modprobe.d/99-opentabletdriver.conf /etc/modprobe.d/99-opentabletdriver.conf
-        sudo ln -s /usr/lib/opentabletdriver-config/modules-load.d/opentabletdriver.conf /etc/modules-load.d/opentabletdriver.conf
+        sudo ln -sf /usr/lib/opentabletdriver-config/udev/rules.d/70-opentabletdriver.rules /etc/udev/rules.d/70-opentabletdriver.rules
+        sudo ln -sf /usr/lib/opentabletdriver-config/modprobe.d/99-opentabletdriver.conf /etc/modprobe.d/99-opentabletdriver.conf
+        sudo ln -sf /usr/lib/opentabletdriver-config/modules-load.d/opentabletdriver.conf /etc/modules-load.d/opentabletdriver.conf
         sudo touch /etc/.otb-toggled
         echo "Enabled OpenTabletDriver."
+
+        if gum confirm --default="no" "Reboot your computer to apply changes?" ; then
+            reboot
+        fi
     fi

--- a/mkosi.extra/usr/share/apollo/justfile
+++ b/mkosi.extra/usr/share/apollo/justfile
@@ -20,3 +20,20 @@ toggle-automatic-updates:
         echo "Disabling automatic updates..."
         systemctl disable --now uupd.timer
     fi
+
+# Toggles OpenTabletDriver (disables built-in kernel tablet drivers)
+toggle-opentabletdriver:
+    #!/bin/bash
+    if stat /etc/.otb-toggled &>/dev/null; then
+        sudo unlink /etc/udev/rules.d/70-opentabletdriver.rules
+        sudo unlink /etc/modprobe.d/99-opentabletdriver.conf
+        sudo unlink /etc/modules-load.d/opentabletdriver.conf
+        sudo rm /etc/.otb-toggled
+        echo "Disabled OpenTabletDriver."
+    else
+        sudo ln -s /usr/lib/opentabletdriver-config/udev/rules.d/70-opentabletdriver.rules /etc/udev/rules.d/70-opentabletdriver.rules
+        sudo ln -s /usr/lib/opentabletdriver-config/modprobe.d/99-opentabletdriver.conf /etc/modprobe.d/99-opentabletdriver.conf
+        sudo ln -s /usr/lib/opentabletdriver-config/modules-load.d/opentabletdriver.conf /etc/modules-load.d/opentabletdriver.conf
+        sudo touch /etc/.otb-toggled
+        echo "Enabled OpenTabletDriver."
+    fi

--- a/mkosi.postinst.chroot
+++ b/mkosi.postinst.chroot
@@ -52,4 +52,5 @@ EOF
 
 # Remove packages that are only used for building
 pacman -Rs --noconfirm \
-    crane
+    crane \
+    jq

--- a/mkosi.prepare.d/otb-rules.chroot
+++ b/mkosi.prepare.d/otb-rules.chroot
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ouex pipefail
+
+cd /tmp
+otb_tag=$(curl -s "https://api.github.com/repos/OpenTabletDriver/OpenTabletDriver/releases/latest" | jq -r '.tag_name')
+git clone https://github.com/opentabletdriver/opentabletdriver --branch ${otb_tag} && cd opentabletdriver
+
+otb_install_dir=/usr/lib/opentabletdriver-config
+install -Dm0644 <(./generate-rules.sh) ${otb_install_dir}/udev/rules.d/70-opentabletdriver.rules
+install -Dm0644 eng/bash/Generic/usr/lib/modprobe.d/99-opentabletdriver.conf -t ${otb_install_dir}/modprobe.d
+install -Dm0644 eng/bash/Generic/usr/lib/modules-load.d/opentabletdriver.conf -t ${otb_install_dir}/modules-load.d


### PR DESCRIPTION
Recreated version of #37

This is a PR that will add in a toggleable set of rules for [OpenTabletDriver](https://opentabletdriver.net).

- [x] Automatically updated dormant rules in `/usr/lib/opentabletdriver-config`
- [x] `ajust` script to toggle these rules on/off with a symlink (also should install/uninstall the flatpak)
