### PR TITLE
chore(ci): allow the usage of free disk space on arm64

### DIFF
--- a/.github/workflows/build-bootc-image.yaml
+++ b/.github/workflows/build-bootc-image.yaml
@@ -62,7 +62,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Free disk space
-        if: matrix.platform != 'arm64'
         uses: hastd/free-disk-space@68572aeaadb7f76bd408246328e95926323402b5 # v0.1.2
         with:
           exclude: |


### PR DESCRIPTION
It started to fail on arm64 as well: https://github.com/zirconium-dev/zirconium/actions/runs/26705179936/job/78704960668

Although Apollo doesn't even have arm64 build it is unneeded anyway