### PR TITLE
feat: build and push images to a stable channel

### DIFF
--- a/.github/workflows/build-latest.yaml
+++ b/.github/workflows/build-latest.yaml
@@ -1,5 +1,5 @@
 ---
-name: Build container image
+name: Build latest images
 on:
   pull_request:
     branches:

--- a/.github/workflows/build-stable.yaml
+++ b/.github/workflows/build-stable.yaml
@@ -1,0 +1,34 @@
+---
+name: Build stable images
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # TODO: long-term, this should be weekly builds. Ideally closer to either beta or GA.
+    - cron: "05 10 * * *" # 10:05am UTC everyday
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  apollo:
+    name: apollo
+    uses: ./.github/workflows/build-bootc-image.yaml
+    with:
+      image-name: "apollo"
+      image-tag: "stable"
+      profiles: ""
+    secrets: inherit
+
+  apollo-nvidia:
+    name: apollo-nvidia
+    uses: ./.github/workflows/build-bootc-image.yaml
+    with:
+      image-name: "apollo-nvidia"
+      image-tag: "stable"
+      profiles: "nvidia"
+    secrets: inherit


### PR DESCRIPTION
This is part one of #47. Right now, Apollo images build both daily and whenever a commit is pushed to main, which means that any change is available to be downloaded and updated. This change builds images to a `stable` branch, currently still building daily but can be slowed down later as needed.

This is currently waiting on #43, so that lts branches can be properly incorporated into stable and latest.