### PR TITLE
fix(desktop): remove lstopo desktop entry

### DIFF
--- a/mkosi.conf.d/gnome.conf
+++ b/mkosi.conf.d/gnome.conf
@@ -37,6 +37,7 @@ RemoveFiles=
         /usr/share/applications/bvnc.desktop
         /usr/share/applications/hplip.desktop
         /usr/share/applications/hp-uiscan.desktop
+        /usr/share/applications/lstopo.desktop
         /usr/share/applications/stoken-gui.desktop
         /usr/share/applications/stoken-gui-small.desktop
         /usr/share/applications/qv4l2.desktop


### PR DESCRIPTION
Remove this useless entry from the desktop, it doesn't even have an icon

This is just the desktop entry, the program is still available

<img width="793" height="554" alt="image" src="https://github.com/user-attachments/assets/af24658a-5f83-43c1-aa87-e67fb1a83549" />
