### PR TITLE
feat: Build images using the Arch Linux Archive

### DIFF
--- a/.github/workflows/reusable-build-bootc.yaml
+++ b/.github/workflows/reusable-build-bootc.yaml
@@ -82,8 +82,11 @@ jobs:
         uses: systemd/mkosi@c4c3d793d0f6f0a2f26895de5ed9382396f36bb5
 
       - name: Set mkosi.version
-        # We need to do this because mkosi.version is not persistent between builds on CI
-        run: skopeo list-tags docker://${IMAGE_REGISTRY}/${IMAGE_NAME} | jq --arg date "$(date -u +%Y%m%d)" -r '.Tags[] | select(startswith($date+"."))' | sort -n | tail -1 > mkosi.version
+        run: |
+          # We need to do this because mkosi.version is not persistent between builds on CI.
+          # Grab what would be the default image version right now and then use it to see if any other images with this major version have been built yet (we omit the .0 for the search)
+          IMAGE_VERSION=$(./mkosi.bump)
+          skopeo list-tags docker://${IMAGE_REGISTRY}/${IMAGE_NAME} | jq --arg update_date "${IMAGE_VERSION:0:8}" -r '.Tags[] | select(startswith($update_date+"."))' | sort -n | tail -1 > mkosi.version
 
       - name: Render configuration (for debugging)
         run: mkosi cat-config --debug

--- a/mkosi.bump
+++ b/mkosi.bump
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
-from datetime import datetime, timezone
+from datetime import datetime
+import urllib.request
 
 DEFAULT_INDEX=0
 
-cur_date = datetime.now(timezone.utc).strftime("%Y%m%d")
+# We want the day of the most recent Arch Linux Archive update
+arch_linux_archive = urllib.request.urlopen("https://archive.archlinux.org/repos/last/lastupdate", timeout=30)
+latest_date = datetime.strptime(arch_linux_archive.getheader('last-modified'), '%a, %d %b %Y %H:%M:%S %Z').strftime('%Y%m%d')
 old_date = None
 old_index = 0
 
@@ -18,9 +21,8 @@ except FileNotFoundError, ValueError:
     pass
 
 # If the date timestamp (YYYYMMDD) of the last built version is the same as the one we want to build, increment the counter index. If not, reset to 0
-if old_date != cur_date:
-    print(f"{cur_date}.{DEFAULT_INDEX}")
+if old_date != latest_date:
+    print(f"{latest_date}.{DEFAULT_INDEX}")
 else:
     new_index = old_index + 1
-    print(f"{cur_date}.{new_index}")
-
+    print(f"{latest_date}.{new_index}")

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -3,6 +3,9 @@ MinimumVersion=26~devel
 
 [Distribution]
 Distribution=arch
+Repositories=core
+			extra
+			multilib
 
 [Build]
 ToolsTree=default

--- a/mkosi.conf.d/extra.conf
+++ b/mkosi.conf.d/extra.conf
@@ -15,7 +15,3 @@ Packages=
         ttf-liberation
         spice-vdagent
         steam-devices
-
-[Build]
-SandboxTrees=
-        repos/multilib.conf:/etc/pacman.d/multilib.conf

--- a/mkosi.configure
+++ b/mkosi.configure
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Grab our input data
+DATA=$(jq "." /dev/stdin)
+
+# Convert the image version into an Arch Linux Archive reference
+UPDATE_DATE="${IMAGE_VERSION:0:4}/${IMAGE_VERSION:4:2}/${IMAGE_VERSION:6:2}"
+
+# Update the configuration data to reflect this
+echo $(jq --arg update_date "$UPDATE_DATE" '.Snapshot=$update_date' <<< $DATA) > /dev/stdout

--- a/mkosi.extra/usr/lib/tmpfiles.d/80-pacman-mirrorlist.conf
+++ b/mkosi.extra/usr/lib/tmpfiles.d/80-pacman-mirrorlist.conf
@@ -1,0 +1,2 @@
+# Link from /etc/pacman.d/mirrorlist to /usr/share/pacman/pacman.d/mirrorlist so it updates with the image
+L+ /etc/pacman.d/mirrorlist - - - - ../../usr/share/pacman/pacman.d/mirrorlist

--- a/mkosi.profiles/bootc/mkosi.postinst.chroot
+++ b/mkosi.profiles/bootc/mkosi.postinst.chroot
@@ -52,6 +52,18 @@ tee -a /etc/pacman.conf <<EOL
 Include = /etc/pacman.d/mirrorlist
 EOL
 
+# Convert the image version into an Arch Linux Archive reference
+UPDATE_DATE="${IMAGE_VERSION:0:4}/${IMAGE_VERSION:4:2}/${IMAGE_VERSION:6:2}"
+
+# Set our mirrorlist to use the Arch Linux Archive instead
+# We sym link this from /etc/pacman.d/mirrorlist using a tmpfiles configuration
+USR_PACMAN_CONF=/usr/share/pacman/pacman.d
+mkdir -p $USR_PACMAN_CONF
+
+cat > $USR_PACMAN_CONF/mirrorlist <<EOF
+Server = https://archive.archlinux.org/repos/${UPDATE_DATE}/\$repo/os/\$arch
+EOF
+
 # Disable the pacman sandbox
 # OCI runtimes (such as containerd) do not have proper support for landlock, 
 # which means pacman breaks when this image is running in a container.

--- a/repos/multilib.conf
+++ b/repos/multilib.conf
@@ -1,6 +1,0 @@
-[multilib]
-Server = https://fastly.mirror.pkgbuild.com/$repo/os/$arch
-Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch
-Server = https://ftpmirror.infania.net/mirror/archlinux/$repo/os/$arch
-Server = https://mirror.rackspace.com/archlinux/$repo/os/$arch
-


### PR DESCRIPTION
This has a number of advantages:
- This is a step closer to reproducible builds, though third-party repos are still not reproducible currently
- Builds should be more consistent and not error because a package got updated mid-transaction
- Local layering is possible via sysexts

`IMAGE_VERSION` now also refers to the date of the archive used, not necessarily the date on which the build occurred.